### PR TITLE
Update regular expression with more strictness

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ stream.on('tweet', (tweet) => {
         fullText = extended_tweet.full_text || '';
     }
 
-    const re = /(Kyiv|Kiev)/i;
+    // We need to make sure that Kiev is really a separate word,
+    // but not some coincidence somwhere in "blablaKievblabla"
+    const re = /(\s+|^)(Kyiv|Kiev)(\s+|$)/im;
 
     if (text.match(re) || fullText.match(re)) {
         likeTweet(tweet.id_str);


### PR DESCRIPTION
Update regular expression with more strictness

There are cases, with old regular expression, when `blablakievblabla` would trigger a match because of literally looking up `Kiev` or `Kyiv`. This PR add more context and checks that `Kiev` or `Kyiv` is wrapped with whitespaces around, so match will be triggered only when Kiev is used as a separate word, ignoring all the cases like `blabla Kievblabla` and so on...